### PR TITLE
Fix type imports for Node16 module resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@
  * @typedef {import('mdast-util-to-markdown').Options} ToMarkdownExtension
  * @typedef {import('mdast-util-to-markdown').Handle} ToMarkdownHandle
  * @typedef {import('estree-jsx').Program} Program
- * @typedef {import('./complex-types').MdxFlowExpression} MdxFlowExpression
- * @typedef {import('./complex-types').MdxTextExpression} MdxTextExpression
+ * @typedef {import('./complex-types.js').MdxFlowExpression} MdxFlowExpression
+ * @typedef {import('./complex-types.js').MdxTextExpression} MdxTextExpression
  */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "Node16",
     "allowJs": true,
     "checkJs": true,
     "declaration": true,


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The TypeScript `node16` module resolution is more strict and requires the `.js` file extension, even for type imports.

<!--do not edit: pr-->
